### PR TITLE
fix: skip Sentry capture for context cancellation errors

### DIFF
--- a/internal/api/graphql/resolver/resolver.go
+++ b/internal/api/graphql/resolver/resolver.go
@@ -4,6 +4,7 @@ package resolver
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"os"
 	"strings"
@@ -213,19 +214,22 @@ func GraphQLHandler(resolver *Resolver, allowedOrigins []string, oidcVerifier *m
 		logger := logging.FromContext(ctx)
 		if expected {
 			logger.Warn("graphql user error", fields...)
+	} else {
+		logger.Error("graphql resolver error", append(fields, zap.String("query", query), zap.Error(e))...)
+		// Skip Sentry capture for context cancellation errors (client disconnects, etc.)
+		if errors.Is(e, context.Canceled) || strings.Contains(e.Error(), "canceling statement due to user request") {
+			logger.Warn("graphql resolver error (client disconnect, skipping Sentry)", append(fields, zap.String("query", query))...)
+		} else if hub := sentry.GetHubFromContext(ctx); hub != nil {
+			hub.WithScope(func(scope *sentry.Scope) {
+				scope.SetTag("graphql.operation", opName)
+				scope.SetTag("graphql.path", path)
+				scope.SetContext("graphql", map[string]any{"query": query})
+				hub.CaptureException(e)
+			})
 		} else {
-			logger.Error("graphql resolver error", append(fields, zap.String("query", query), zap.Error(e))...)
-			if hub := sentry.GetHubFromContext(ctx); hub != nil {
-				hub.WithScope(func(scope *sentry.Scope) {
-					scope.SetTag("graphql.operation", opName)
-					scope.SetTag("graphql.path", path)
-					scope.SetContext("graphql", map[string]any{"query": query})
-					hub.CaptureException(e)
-				})
-			} else {
-				sentry.CaptureException(e)
-			}
+			sentry.CaptureException(e)
 		}
+	}
 		return err
 	})
 	h.SetRecoverFunc(func(ctx context.Context, err any) error {

--- a/internal/api/graphql/resolver/resolver.go
+++ b/internal/api/graphql/resolver/resolver.go
@@ -212,24 +212,25 @@ func GraphQLHandler(resolver *Resolver, allowedOrigins []string, oidcVerifier *m
 			zap.String("message", err.Message),
 		}
 		logger := logging.FromContext(ctx)
-		if expected {
+		switch {
+		case expected:
 			logger.Warn("graphql user error", fields...)
-	} else {
-		logger.Error("graphql resolver error", append(fields, zap.String("query", query), zap.Error(e))...)
-		// Skip Sentry capture for context cancellation errors (client disconnects, etc.)
-		if errors.Is(e, context.Canceled) || strings.Contains(e.Error(), "canceling statement due to user request") {
-			logger.Warn("graphql resolver error (client disconnect, skipping Sentry)", append(fields, zap.String("query", query))...)
-		} else if hub := sentry.GetHubFromContext(ctx); hub != nil {
-			hub.WithScope(func(scope *sentry.Scope) {
-				scope.SetTag("graphql.operation", opName)
-				scope.SetTag("graphql.path", path)
-				scope.SetContext("graphql", map[string]any{"query": query})
-				hub.CaptureException(e)
-			})
-		} else {
-			sentry.CaptureException(e)
+		case errors.Is(e, context.Canceled) || strings.Contains(e.Error(), "canceling statement due to user request"):
+			// Client disconnected mid-request; log at Warn and skip Sentry.
+			logger.Warn("graphql resolver error (client disconnect)", append(fields, zap.String("query", query))...)
+		default:
+			logger.Error("graphql resolver error", append(fields, zap.String("query", query), zap.Error(e))...)
+			if hub := sentry.GetHubFromContext(ctx); hub != nil {
+				hub.WithScope(func(scope *sentry.Scope) {
+					scope.SetTag("graphql.operation", opName)
+					scope.SetTag("graphql.path", path)
+					scope.SetContext("graphql", map[string]any{"query": query})
+					hub.CaptureException(e)
+				})
+			} else {
+				sentry.CaptureException(e)
+			}
 		}
-	}
 		return err
 	})
 	h.SetRecoverFunc(func(ctx context.Context, err any) error {


### PR DESCRIPTION
## Sentry issues
https://nuagemagiquedev.sentry.io/issues/TSB-SERVICE-5/
https://nuagemagiquedev.sentry.io/issues/TSB-SERVICE-6/

Short ID: TSB-SERVICE-5, TSB-SERVICE-6 (same request, same trace_id)
Frequency: 1 event each, first seen 37 min ago
Project: tsb-service
Level: error

## Stack trace (top frames)
```
GraphQLHandler.func3 (resolver.go:219)
  → resolver.go:223 hub.CaptureException(e)
```
Triggered from `restaurantConfig.availableSlotsToday` (TSB-5) and `restaurantConfig.nextOpeningAt` (TSB-6) on the same Mobile Safari request.

## Diagnosis
A Mobile Safari client disconnected while the server was processing a `restaurantConfig` GraphQL query with multiple resolver fields. The HTTP context cancellation cascades to the PostgreSQL driver (`pq: canceling statement due to user request`) and produces `context canceled` errors. The current GraphQL error handler captures *all* errors to Sentry unconditionally. These are expected network events when clients disconnect, not application bugs.

## What this PR changes
- `internal/api/graphql/resolver/resolver.go` — Add a guard before `sentry.CaptureException(e)` to skip Sentry capture when the error wraps `context.Canceled` or contains "canceling statement due to user request". These are still logged at Warn level so they appear in logs but don't create Sentry issues.

## How to verify
- Check that context cancellation errors no longer appear as new Sentry issues
- Verify existing Sentry alerts for real bugs still fire correctly
- Confirm logs still show these events at Warn level

## Confidence
high — the pattern is a standard Go idiom (`errors.Is(e, context.Canceled)`) applied at the Sentry capture boundary. No business logic changed.

---
🤖 Auto-generated by Hermes (sentry-fixer skill). Always review before merging.