### PR TITLE
fix: suppress gqlgen input validation errors from Sentry (TSB-SERVICE-1)

### DIFF
--- a/internal/api/graphql/resolver/resolver.go
+++ b/internal/api/graphql/resolver/resolver.go
@@ -215,9 +215,12 @@ func GraphQLHandler(resolver *Resolver, allowedOrigins []string, oidcVerifier *m
 		switch {
 		case expected:
 			logger.Warn("graphql user error", fields...)
-		case errors.Is(e, context.Canceled) || strings.Contains(e.Error(), "canceling statement due to user request"):
-			// Client disconnected mid-request; log at Warn and skip Sentry.
-			logger.Warn("graphql resolver error (client disconnect)", append(fields, zap.String("query", query))...)
+		// gqlgen validation errors (client-sent malformed input) and context
+		// cancellation errors (client disconnects) are expected; skip Sentry.
+		case errors.Is(e, context.Canceled) ||
+			strings.Contains(e.Error(), "canceling statement due to user request") ||
+			strings.HasPrefix(e.Error(), "input: "):
+			logger.Warn("graphql resolver error (expected, skipping Sentry)", append(fields, zap.String("query", query))...)
 		default:
 			logger.Error("graphql resolver error", append(fields, zap.String("query", query), zap.Error(e))...)
 			if hub := sentry.GetHubFromContext(ctx); hub != nil {


### PR DESCRIPTION
## Sentry issue
https://nuagemagiquedev.sentry.io/issues/113212352/

Short ID: TSB-SERVICE-1
Frequency: 6 events, first seen 2026-04-18, last seen 2026-05-16
Project: go-gin
Level: error

## Stack trace (top frames)
```
*gqlerror.Error: input: variable.input.status enums must be ints or strings
  at GraphQLHandler.func3 (resolver.go:224)
  at (*Server).ServeHTTP (server.go:166)
  at POST.Do (http_post.go:122)
  at (*Executor).DispatchError (executor.go:158)
  at AddError (context_response.go:63)
```

## Diagnosis
Two distinct gqlgen validation error patterns are being reported to Sentry:
1. `input: no operation provided` — client POSTs to `/api/v1/graphql` with no body or empty body
2. `input: variable.input.status enums must be ints or strings` — client sends an `OrderHistory` query but the `status` variable contains malformed data (not a valid enum string/int)

Both originate from the graphql endpoint's validation layer before any resolver code runs. The server validates correctly — these are client-side input errors, not server bugs. The error presenter was only filtering out `context.Cancellation` errors, so these validation errors fell through to Sentry capture.

## What this PR changes
- `internal/api/graphql/resolver/resolver.go`: Added `strings.HasPrefix(e.Error(), "input: ")` to the skip-Sentry condition, so all gqlgen input validation errors ("input: no operation provided", "input: variable.* enums must be ints or strings", etc.) are logged at warn-level but not captured to Sentry.

## How to verify
- Deploy and confirm that future client-side gqlgen validation errors no longer create new Sentry issues
- Confirm the existing TSB-SERVICE-1 issue is marked resolved after deploy
- Check logs for "graphql resolver error (expected, skipping Sentry)" to verify these are still being logged

## Confidence
high — the fix adds a single condition matching the gqlgen error prefix pattern, consistent with the existing context-cancellation filter.

---
🤖 Auto-generated by Hermes (sentry-fixer skill). Always review before merging.