### PR TITLE
fix(sentry-TSB-SERVICE-7): refuse request on user lookup failure

### DIFF
--- a/internal/api/graphql/resolver/resolver.go
+++ b/internal/api/graphql/resolver/resolver.go
@@ -149,6 +149,8 @@ func GraphQLHandler(resolver *Resolver, allowedOrigins []string, oidcVerifier *m
 						// columns and produce "invalid input syntax for type
 						// uuid". Leave userID empty so the @auth directive
 						// sees no authenticated user and returns UNAUTHENTICATED.
+						zap.L().Warn("failed to resolve Zitadel user on WS init — proceeding unauthenticated",
+							zap.String("sub", sub), zap.Error(lookupErr))
 						return ctx, &initPayload, nil
 					}
 					ctx = utils.SetUserID(ctx, appID)

--- a/internal/api/graphql/resolver/resolver.go
+++ b/internal/api/graphql/resolver/resolver.go
@@ -143,11 +143,15 @@ func GraphQLHandler(resolver *Resolver, allowedOrigins []string, oidcVerifier *m
 					ctx = utils.SetUserID(ctx, sub)
 				} else {
 					appID, lookupErr := resolver.UserService.ResolveZitadelID(ctx, sub, "", "", "")
-					if lookupErr == nil {
-						ctx = utils.SetUserID(ctx, appID)
-					} else {
-						ctx = utils.SetUserID(ctx, sub)
+					if lookupErr != nil {
+						// Don't set a raw Zitadel sub (often a numeric Google
+						// user ID) as the userID — it will hit Postgres UUID
+						// columns and produce "invalid input syntax for type
+						// uuid". Leave userID empty so the @auth directive
+						// sees no authenticated user and returns UNAUTHENTICATED.
+						return ctx, &initPayload, nil
 					}
+					ctx = utils.SetUserID(ctx, appID)
 				}
 				ctx = utils.SetIsAdmin(ctx, isAdmin)
 				ctx = utils.SetTokenExpiry(ctx, exp)

--- a/internal/shared/middleware/oidc.go
+++ b/internal/shared/middleware/oidc.go
@@ -209,28 +209,34 @@ func (v *OIDCVerifier) verifyAndSetContext(c *gin.Context, tokenStr string) bool
 	)
 
 	// Resolve Zitadel sub → app user UUID (with JIT provisioning)
-	userID := sub
-	if v.userLookup != nil {
-		appID, lookupErr := v.userLookup.ResolveZitadelID(
-			c.Request.Context(), sub, email, givenName, familyName,
-		)
-		if lookupErr != nil {
-			zap.L().Warn("failed to resolve Zitadel user", zap.String("sub", sub), zap.Error(lookupErr))
-			// Fall back to raw sub — downstream will handle the error
-		} else {
-			userID = appID
-		}
+	if v.userLookup == nil {
+		// No user lookup configured — we cannot resolve the Zitadel sub to an
+		// app user UUID. Refuse the request rather than risking a raw sub
+		// (often a numeric Google user ID) hitting Postgres UUID columns.
+		zap.L().Warn("OIDC verifier has no userLookup configured — refusing request",
+			zap.String("sub", sub))
+		return false
 	}
-
-	ctx := utils.SetUserID(c.Request.Context(), userID)
+	appID, lookupErr := v.userLookup.ResolveZitadelID(
+		c.Request.Context(), sub, email, givenName, familyName,
+	)
+	// On resolution failure, don't fall back to the raw sub — it's an
+	// opaque provider identifier (e.g. a Google numeric user ID) that
+	// downstream code expects to be a UUID. Setting it causes
+	// "pq: invalid input syntax for type uuid" on any user table lookup.
+	if lookupErr != nil {
+		zap.L().Warn("failed to resolve Zitadel user — refusing request",
+			zap.String("sub", sub), zap.Error(lookupErr))
+		return false
+	}
+	ctx := utils.SetUserID(c.Request.Context(), appID)
 	ctx = utils.SetZitadelSub(ctx, sub)
 	ctx = utils.SetIsAdmin(ctx, isAdmin)
 	if expRaw, ok := authCtx.Claims["exp"].(float64); ok {
 		ctx = utils.SetTokenExpiry(ctx, time.Unix(int64(expRaw), 0).UTC())
 	}
 	c.Request = c.Request.WithContext(ctx)
-	c.Set(string(utils.UserIDKey), userID)
-
+	c.Set(string(utils.UserIDKey), appID)
 	return true
 }
 

--- a/internal/shared/middleware/oidc.go
+++ b/internal/shared/middleware/oidc.go
@@ -170,6 +170,26 @@ func extractToken(c *gin.Context) string {
 	return ""
 }
 
+// resolveAppUserID resolves a Zitadel sub to an app user UUID via the
+// configured userLookup (with JIT provisioning). Returns ("", false) if no
+// lookup is configured or resolution fails. Callers should refuse the request
+// when ok is false — raw subs may be opaque provider identifiers (e.g. Google
+// numeric IDs) that break Postgres UUID columns downstream.
+func (v *OIDCVerifier) resolveAppUserID(ctx context.Context, sub, email, givenName, familyName string) (string, bool) {
+	if v.userLookup == nil {
+		zap.L().Warn("OIDC verifier has no userLookup configured — refusing request",
+			zap.String("sub", sub))
+		return "", false
+	}
+	appID, err := v.userLookup.ResolveZitadelID(ctx, sub, email, givenName, familyName)
+	if err != nil {
+		zap.L().Warn("failed to resolve Zitadel user — refusing request",
+			zap.String("sub", sub), zap.Error(err))
+		return "", false
+	}
+	return appID, true
+}
+
 // verifyAndSetContext verifies the JWT and sets userID/isAdmin in context.
 func (v *OIDCVerifier) verifyAndSetContext(c *gin.Context, tokenStr string) bool {
 	authCtx, err := v.authorizer.CheckAuthorization(c.Request.Context(), "Bearer "+tokenStr)
@@ -209,24 +229,8 @@ func (v *OIDCVerifier) verifyAndSetContext(c *gin.Context, tokenStr string) bool
 	)
 
 	// Resolve Zitadel sub → app user UUID (with JIT provisioning)
-	if v.userLookup == nil {
-		// No user lookup configured — we cannot resolve the Zitadel sub to an
-		// app user UUID. Refuse the request rather than risking a raw sub
-		// (often a numeric Google user ID) hitting Postgres UUID columns.
-		zap.L().Warn("OIDC verifier has no userLookup configured — refusing request",
-			zap.String("sub", sub))
-		return false
-	}
-	appID, lookupErr := v.userLookup.ResolveZitadelID(
-		c.Request.Context(), sub, email, givenName, familyName,
-	)
-	// On resolution failure, don't fall back to the raw sub — it's an
-	// opaque provider identifier (e.g. a Google numeric user ID) that
-	// downstream code expects to be a UUID. Setting it causes
-	// "pq: invalid input syntax for type uuid" on any user table lookup.
-	if lookupErr != nil {
-		zap.L().Warn("failed to resolve Zitadel user — refusing request",
-			zap.String("sub", sub), zap.Error(lookupErr))
+	appID, ok := v.resolveAppUserID(c.Request.Context(), sub, email, givenName, familyName)
+	if !ok {
 		return false
 	}
 	ctx := utils.SetUserID(c.Request.Context(), appID)

--- a/internal/shared/middleware/oidc_test.go
+++ b/internal/shared/middleware/oidc_test.go
@@ -1,0 +1,61 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type stubUserLookup struct {
+	appID string
+	err   error
+	calls int
+}
+
+func (s *stubUserLookup) ResolveZitadelID(_ context.Context, _, _, _, _ string) (string, error) {
+	s.calls++
+	return s.appID, s.err
+}
+
+func TestResolveAppUserID(t *testing.T) {
+	const sub = "373762126155612239" // Google numeric ID — not a UUID
+
+	t.Run("nil userLookup refuses the request", func(t *testing.T) {
+		v := &OIDCVerifier{}
+		appID, ok := v.resolveAppUserID(context.Background(), sub, "", "", "")
+		if ok {
+			t.Fatalf("expected ok=false when userLookup is nil, got appID=%q", appID)
+		}
+		if appID != "" {
+			t.Fatalf("expected empty appID on refusal, got %q", appID)
+		}
+	})
+
+	t.Run("lookup error refuses the request", func(t *testing.T) {
+		lookup := &stubUserLookup{err: errors.New("db down")}
+		v := &OIDCVerifier{userLookup: lookup}
+		appID, ok := v.resolveAppUserID(context.Background(), sub, "", "", "")
+		if ok {
+			t.Fatalf("expected ok=false on lookup error, got appID=%q", appID)
+		}
+		if appID != "" {
+			t.Fatalf("expected empty appID on refusal, got %q (raw sub must not leak)", appID)
+		}
+		if lookup.calls != 1 {
+			t.Fatalf("expected userLookup called once, got %d", lookup.calls)
+		}
+	})
+
+	t.Run("successful lookup returns the app UUID", func(t *testing.T) {
+		want := "11111111-1111-1111-1111-111111111111"
+		lookup := &stubUserLookup{appID: want}
+		v := &OIDCVerifier{userLookup: lookup}
+		appID, ok := v.resolveAppUserID(context.Background(), sub, "u@example.com", "First", "Last")
+		if !ok {
+			t.Fatalf("expected ok=true on successful lookup")
+		}
+		if appID != want {
+			t.Fatalf("expected appID=%q, got %q", want, appID)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Fixed a bug where a raw Zitadel `sub` claim (e.g. `"373762126155612239"` — a Google numeric user ID) was falling through to GraphQL resolvers and causing Postgres UUID type errors:

```
pq: invalid input syntax for type uuid: "373762126155612239"\n```

## Root Cause

When `ResolveZitadelID()` failed, both the HTTP middleware and the WebSocket InitFunc fell back to using the raw Zitadel `sub` as the context userID. Downstream resolvers passed this directly to `SELECT * FROM users WHERE id = $1`, which Postgres rejected because `id` is a `uuid` column.

This was a long-standing safety-net fallthrough in `verifyAndSetContext` (oidc.go:212-223) and the WebSocket InitFunc (resolver.go:145-150). The Zitadel `sub` can be **any opaque string** depending on the upstream IdP — Google uses numeric user IDs, Apple uses similar opaque identifiers — so treating it as a UUID was never safe.

## Changes

### `internal/shared/middleware/oidc.go`
- **Removed** the fallback path: `userID := sub` that was set when ResolveZitadelID failed
- **Now returns `false`** (request refused) when userLookup is nil or ResolveZitadelID errors
- The HTTP middleware already handles `return false` — StrictAuth returns 401, OptionalAuth tries the POS fallback

### `internal/api/graphql/resolver/resolver.go`
- **Removed** the WebSocket InitFunc fallback: `ctx = utils.SetUserID(ctx, sub)`
- **Returns early** leaving userID empty so the `@auth` directive sees no authenticated user and responds with `UNAUTHENTICATED`

## Impact

- Users whose `ResolveZitadelID` fails will get a clean auth rejection instead of a database query error
- Resolves **TSB-SERVICE-7** (1 occurrence)