### PR TITLE
fix: wrap preferred ready time validation error as USER_ERROR in createOrder

### DIFF
--- a/internal/api/graphql/resolver/order.go
+++ b/internal/api/graphql/resolver/order.go
@@ -71,7 +71,11 @@ func (r *mutationResolver) CreateOrder(ctx context.Context, input model.CreateOr
 		now := time.Now()
 		isOpenNow := config.IsOrderingCurrentlyOpen(now, overrides)
 		if err := validatePreferredReadyTime(input.PreferredReadyTime, config, overrides, now, isOpenNow); err != nil {
-			return nil, err
+			return nil, &gqlerror.Error{
+				Message:    err.Error(),
+				Path:       graphql.GetPath(ctx),
+				Extensions: map[string]any{"code": "USER_ERROR"},
+			}
 		}
 
 		slotTime := now

--- a/internal/api/graphql/resolver/order.go
+++ b/internal/api/graphql/resolver/order.go
@@ -74,7 +74,7 @@ func (r *mutationResolver) CreateOrder(ctx context.Context, input model.CreateOr
 			return nil, &gqlerror.Error{
 				Message:    err.Error(),
 				Path:       graphql.GetPath(ctx),
-				Extensions: map[string]any{"code": "USER_ERROR"},
+				Extensions: map[string]any{"code": "USER_ERROR", "field": "preferredReadyTime"},
 			}
 		}
 


### PR DESCRIPTION
## Sentry issue
https://nuagemagiquedev.sentry.io/issues/121398338/

Short ID: TSB-SERVICE-8
Frequency: 1 event, first seen 2026-05-20, last seen 2026-05-20
Project: go-gin (tsb-service)
Level: error

## Stack trace (top frames)
1. internal/api/graphql/resolver/resolver.go:228 — error presenter capture
2. internal/api/graphql/resolver/resolver.go:224 — GraphQLHandler.func3
3. internal/api/graphql/generated.go:5192 — (*executionContext)._Mutation_createOrder
4. internal/api/graphql/resolver/mappers.go:444 — validatePreferredReadyTime: "preferred ready time is no longer available"

## Diagnosis
The `validatePreferredReadyTime` function in `mappers.go` returns plain `fmt.Errorf` errors for business validation failures (time outside prep window, wrong day, wrong slot, etc.). These errors bubble up from the `CreateOrder` resolver and reach the error presenter in `resolver.go`. The presenter checks for `extensions.code == "USER_ERROR"` to classify errors as expected, but plain `fmt.Errorf` errors have no extensions map, so they fall through to the default branch and are captured by Sentry.

## What this PR changes
- `internal/api/graphql/resolver/order.go` — Wraps the `validatePreferredReadyTime` error in a `gqlerror.Error` with `extensions.code: "USER_ERROR"` before returning it from `CreateOrder`. This matches the pattern already used in `user.go` for `ErrInvalidPhoneNumber`.

## How to verify
- Submit a `createOrder` mutation with a `preferredReadyTime` that is within the minimum preparation window (e.g., a time only a few minutes from now)
- Confirm the GraphQL response contains the validation error in `errors` array with `extensions.code: "USER_ERROR"`
- Confirm the error is NOT reported to Sentry

## Confidence
high — single, unambiguous 5-line change that matches the existing pattern used for `ErrInvalidPhoneNumber` in the same resolver.

---
🤖 Auto-generated by Hermes (sentry-fixer skill). Always review before merging.