### PR TITLE
fix: remove pc.slug column reference from FindCategoriesByProductIDs

### DIFF
--- a/internal/modules/product/infrastructure/repository.go
+++ b/internal/modules/product/infrastructure/repository.go
@@ -748,7 +748,6 @@ func (r *ProductRepository) FindCategoriesByProductIDs(
         p.id               AS product_id,
         pc.id              AS category_id,
         pc.order           AS category_order,
-        pc.slug            AS category_slug,
         pct.language       AS language,
         pct.name           AS category_name
     FROM products p
@@ -775,7 +774,6 @@ func (r *ProductRepository) FindCategoriesByProductIDs(
 			ProductID     uuid.UUID `db:"product_id"`
 			CategoryID    uuid.UUID `db:"category_id"`
 			CategoryOrder int       `db:"category_order"`
-			CategorySlug  string    `db:"category_slug"`
 			Language      string    `db:"language"`
 			CategoryName  string    `db:"category_name"`
 		}
@@ -801,7 +799,7 @@ func (r *ProductRepository) FindCategoriesByProductIDs(
 			catMap[cr.CategoryID] = &domain.Category{
 				ID:    cr.CategoryID,
 				Order: cr.CategoryOrder,
-				Slug:  cr.CategorySlug,
+				Slug:  "",
 				Translations: []domain.Translation{{
 					Language: cr.Language,
 					Name:     cr.CategoryName,


### PR DESCRIPTION
## Sentry issue
https://nuagemagiquedev.sentry.io/issues/TSB-SERVICE-9

Short ID: TSB-SERVICE-9
Frequency: 500 events, first seen 2026-05-25, last seen 2026-05-25
Project: tsb-service (go-gin)
Level: error

## Stack trace (top frames)
```
*gqlerror.Error: input:1:584: orders[57].items[1].product.category failed to load product category: failed to fetch categories: pq: column pc.slug does not exist at position 6:9 (42703)
at 1 (/app/internal/api/graphql/resolver/resolver.go:238)
at GraphQLHandler.func3 (/app/internal/api/graphql/resolver/resolver.go:234)
at (*executionContext)._Product_category (/app/internal/api/graphql/generated.go:8737)
at (*executionContext)._OrderProduct (/app/internal/api/graphql/generated.go:7220)
```

## Diagnosis
The `FindCategoriesByProductIDs` query in `repository.go` references `pc.slug` (the `slug` column on `product_categories`), but this column does not exist in the production database. A migration (`20260524120000_add_slug_to_product_categories.sql`) was added to create the column but has not been applied to the running environment yet. The code was deployed with the column reference before the migration landed, causing all GraphQL queries that request `product.category` to fail with a 42703 database error.

## What this PR changes
- `internal/modules/product/infrastructure/repository.go` — Remove `pc.slug AS category_slug` from the SELECT query, remove the `CategorySlug` field from the row-scan struct, and set `Slug: ""` in the domain.Category construction (backward-compatible; categories return with empty slug until migration is applied).

## How to verify
- Deploy and trigger a GraphQL query that fetches orders with product categories (e.g. the `Orders` query shown in the Sentry event).
- Confirm no more `pq: column pc.slug does not exist` errors in Sentry.
- Confirm product categories return correctly (with empty slug temporarily).

## Confidence
high — the stack trace directly points to a single missing column reference, and the fix removes it with no other code changes.

---
🤖 Auto-generated by Hermes (sentry-fixer skill). Always review before merging.