### PR TITLE
fix(gqlgen): filter Applebot 'input: no operation provided' errors

### DIFF
--- a/internal/api/graphql/resolver/resolver.go
+++ b/internal/api/graphql/resolver/resolver.go
@@ -224,9 +224,11 @@ func GraphQLHandler(resolver *Resolver, allowedOrigins []string, oidcVerifier *m
 		case errors.Is(e, context.Canceled) || strings.Contains(e.Error(), "canceling statement due to user request"):
 			// Client disconnected mid-request; log at Warn and skip Sentry.
 			logger.Warn("graphql resolver error (client disconnect)", append(fields, zap.String("query", query))...)
-		case err.Path.String() == "input":
+		case strings.HasPrefix(e.Error(), "input: "):
 			// gqlgen pre-execution rejection (malformed GET, parse error,
 			// variable coercion, complexity overflow, etc.); client noise, skip Sentry.
+			// Uses strings.HasPrefix instead of err.Path.String() == "input"
+			// because nil Path (e.g. Applebot empty GET) serializes to "".
 			logger.Warn("graphql resolver error (client malformed request)", append(fields, zap.String("query", query))...)
 		default:
 			logger.Error("graphql resolver error", append(fields, zap.String("query", query), zap.Error(e))...)


### PR DESCRIPTION
## Sentry issue
https://nuagemagiquedev.sentry.io/issues/113212352/

Short ID: TSB-SERVICE-1
Frequency: 19 events, first seen 2026-04-18, last seen 2026-06-02
Project: go-gin
Level: error

## Stack trace (top frames)
```
*gqlerror.Error: input: no operation provided
  at (*Executor).DispatchError     (gqlgen executor.go:158)
  at GET.Do                        (gqlgen http_get.go:91)
  at GraphQLHandler.func5          (resolver/resolver.go:257)
  at (*Server).ServeHTTP           (gqlgen server.go:166)
  at OptionalAuthMiddleware.func14 (middleware/oidc.go:275)
```

## Diagnosis
Applebot (Apple's web crawler) periodically hits `/api/v1/graphql` with bare GET requests containing no GraphQL operation. gqlgen's HTTP_GET transport calls `DispatchError` which routes through the error presenter.

The existing filter on line 227 checked `err.Path.String() == "input"`, but when Applebot sends an empty request, `err.Path` is nil and `Path.String()` returns `""`, so the check silently fails and the error falls through to Sentry.

## What this PR changes
- `internal/api/graphql/resolver/resolver.go`: Replace `err.Path.String() == "input"` with `strings.HasPrefix(e.Error(), "input: ")` — matches all gqlgen pre-execution validation errors regardless of nil Path state.

## How to verify
- Confirm build passes: `go build ./...`
- Test that Applebot requests no longer produce Sentry events (observe no new TSB-SERVICE-1 occurrences after deploy)
- Verify legitimate GraphQL errors still reach Sentry

## Confidence
high — the fix is a single-line change using the exact pattern documented in the project's own gqlgen validation error reference. `strings` package already imported.

---
🤖 Auto-generated by Hermes (sentry-fixer skill). Always review before merging.